### PR TITLE
docs(*): Print authorizationCode and identityToken

### DIFF
--- a/packages/sign_in_with_apple/README.md
+++ b/packages/sign_in_with_apple/README.md
@@ -24,6 +24,8 @@ SignInWithAppleButton(
       ],
     );
 
+    print(credential.authorizationCode);
+    print(credential.identityToken);
     print(credential);
 
     // Now send the credential (especially `credential.authorizationCode`) to your server to create a session


### PR DESCRIPTION
Print authorizationCode and identityToken along with AuthorizationCredential because these are excluded from toString implementation.